### PR TITLE
Mount d64 image via Socket

### DIFF
--- a/software/drive/c1541.cc
+++ b/software/drive/c1541.cc
@@ -603,7 +603,9 @@ int C1541 :: executeCommand(SubsysCommand *cmd)
 	case G64FILE_MOUNT:
 	case MENU_1541_MOUNT:
 	case MENU_1541_MOUNT_GCR:
-		fm->fstat(cmd->path.c_str(), cmd->filename.c_str(), info);
+		if (!(cmd->mode & RUNCODE_MOUNT_BUFFER)) {
+			fm->fstat(cmd->path.c_str(), cmd->filename.c_str(), info);
+		}
         break;
 	default:
 		break;
@@ -641,25 +643,34 @@ int C1541 :: executeCommand(SubsysCommand *cmd)
 	case D64FILE_MOUNT:
 	case D64FILE_MOUNT_UL:
 	case D64FILE_MOUNT_RO:
-		printf("Mounting disk.. %s\n", cmd->filename.c_str());
-		res = fm->fopen(cmd->path.c_str(), cmd->filename.c_str(), flags, &newFile);
-		if(res == FR_OK) {
-			check_if_save_needed(cmd);
-
-			c64_command = new SubsysCommand(cmd->user_interface, SUBSYSID_C64,
-            		C64_UNFREEZE, 0, "", "");
-            c64_command->execute();
-
-			mount_d64(protect, newFile);
-            if ((cmd->functionID == D64FILE_MOUNT_UL) ||
-            	(cmd->functionID == D64FILE_MOUNT_RO)) {
-            	unlink();
-            }
-            if(cmd->functionID == D64FILE_RUN) {
-                c64_command = new SubsysCommand(cmd->user_interface, SUBSYSID_C64,
-                		C64_DRIVE_LOAD, RUNCODE_MOUNT_LOAD_RUN, "", "*");
-                c64_command->execute();
-            }
+		if (!(cmd->mode & RUNCODE_MOUNT_BUFFER)) {
+			printf("Mounting disk.. %s\n", cmd->filename.c_str());
+			res = fm->fopen(cmd->path.c_str(), cmd->filename.c_str(), flags, &newFile);
+		}
+		if(cmd->mode & RUNCODE_MOUNT_BUFFER || res == FR_OK) {
+			if (!(cmd->mode & RUNCODE_NO_CHECKSAVE)) {
+				check_if_save_needed(cmd);
+			}
+			if (!(cmd->mode & RUNCODE_NO_UNFREEZE)) {
+				c64_command = new SubsysCommand(cmd->user_interface, SUBSYSID_C64,
+					C64_UNFREEZE, 0, "", "");
+				c64_command->execute();
+			}
+			if (cmd->mode & RUNCODE_MOUNT_BUFFER) {
+				mount_d64(false, (uint8_t *) cmd->buffer, (uint32_t) cmd->bufferSize);
+				unlink();
+			} else {
+				mount_d64(protect, newFile);
+			}
+			if ((cmd->functionID == D64FILE_MOUNT_UL) ||
+				(cmd->functionID == D64FILE_MOUNT_RO)) {
+				unlink();
+			}
+			if(cmd->functionID == D64FILE_RUN) {
+				c64_command = new SubsysCommand(cmd->user_interface, SUBSYSID_C64,
+						C64_DRIVE_LOAD, RUNCODE_MOUNT_LOAD_RUN, "", "*");
+				c64_command->execute();
+			}
 		} else {
 			printf("Error opening file.\n");
 		}

--- a/software/drive/c1541.h
+++ b/software/drive/c1541.h
@@ -40,6 +40,10 @@
 #define G64FILE_MOUNT_RO   0x2123
 #define G64FILE_MOUNT_UL   0x2124
 
+#define RUNCODE_NO_UNFREEZE  0x01
+#define RUNCODE_NO_CHECKSAVE 0x02
+#define RUNCODE_MOUNT_BUFFER 0x10
+
 typedef enum { e_rom_1541=0, e_rom_1541c=1, e_rom_1541ii=2, e_rom_custom=3, e_rom_unset=99 } t_1541_rom;
 typedef enum { e_ram_none      = 0x00,
                e_ram_8000_BFFF = 0x30,

--- a/software/filemanager/dos.cc
+++ b/software/filemanager/dos.cc
@@ -147,6 +147,14 @@ void Dos :: parse_command(Message *command, Message **reply, Message **status)
        if (cmd >= 0x18 && cmd <= 0x1f)   command->message[1] = 0xff;
        if (cmd >= 0x26 && cmd <= 0x2f)   command->message[1] = 0xff;
     }
+    if (ultimatedosversion == -3)
+    {
+       int cmd = command->message[1];
+       if (cmd >= 0x09 && cmd <= 0x0f)   command->message[1] = 0xff;
+       if (cmd >= 0x16 && cmd <= 0x1f)   command->message[1] = 0xff;
+       if (cmd >= 0x23 && cmd <= 0x2f)   command->message[1] = 0xff;
+       if (cmd == 0x15)   command->message[1] = 0x17;
+    }
     
     switch(command->message[1]) {
         case DOS_CMD_IDENTIFY:

--- a/software/io/c64/c64.cc
+++ b/software/io/c64/c64.cc
@@ -221,7 +221,8 @@ void C64 :: set_emulation_flags(cart_def *def)
         if(getFpgaCapabilities() & CAPAB_COMMAND_INTF) {
         	int choice = cfg->get_value(CFG_CMD_ENABLE);
         	CMD_IF_SLOT_ENABLE = !!choice;
-		ultimatedosversion = choice;
+		if (choice != 3 || ultimatedosversion != -3)
+		   ultimatedosversion = choice;
             CMD_IF_SLOT_BASE = 0x47; // $DF1C
 	    choice = cfg->get_value(CFG_CMD_ALLOW_WRITE);
 	    allowUltimateDosDateSet = choice;

--- a/software/network/socket_dma.cc
+++ b/software/network/socket_dma.cc
@@ -24,8 +24,8 @@
 #define SOCKET_CMD_DMAWRITE    0xFF06
 #define SOCKET_CMD_REUWRITE    0xFF07
 #define SOCKET_CMD_KERNALWRITE 0xFF08
-#define SOCKET_CMD_RUN_IMG     0xFF09
 #define SOCKET_CMD_MOUNT_IMG   0xFF0A
+#define SOCKET_CMD_RUN_IMG     0xFF0B
 
 
 SocketDMA socket_test; // global that causes the object to exist

--- a/software/network/socket_dma.cc
+++ b/software/network/socket_dma.cc
@@ -14,6 +14,7 @@
 #include "dump_hex.h"
 #include "c64.h"
 #include "c64_subsys.h"
+#include "c1541.h"
 
 #define SOCKET_CMD_DMA         0xFF01
 #define SOCKET_CMD_DMARUN      0xFF02
@@ -23,6 +24,8 @@
 #define SOCKET_CMD_DMAWRITE    0xFF06
 #define SOCKET_CMD_REUWRITE    0xFF07
 #define SOCKET_CMD_KERNALWRITE 0xFF08
+#define SOCKET_CMD_RUN_IMG     0xFF09
+#define SOCKET_CMD_MOUNT_IMG   0xFF0A
 
 
 SocketDMA socket_test; // global that causes the object to exist
@@ -50,7 +53,10 @@ void SocketDMA :: parseBuffer(void *load_buffer, int length)
 		remaining -= 2;
 		uint16_t offs;
 		uint32_t offs32;
+		uint32_t len32;
 		uint16_t i;
+
+		// TODO: check len > remaining
 
 		switch(cmd) {
 		case SOCKET_CMD_DMA:
@@ -91,7 +97,26 @@ void SocketDMA :: parseBuffer(void *load_buffer, int length)
 			for (i=2; i<len; i++)
 			   *(uint8_t *)(C64_KERNAL_BASE+1+2*((offs32+i-2)&0x1fff)) = buf[i];
 			break;
+		case SOCKET_CMD_MOUNT_IMG:
+		case SOCKET_CMD_RUN_IMG:
+			// TODO, let 'len' be uint32_t? Beneficial for REU commands too
+			len32 = (uint32_t)len | (((uint32_t)buf[0]) << 16);
+			buf += 1;
+			if (cmd == SOCKET_CMD_MOUNT_IMG) {
+				c64_command = new SubsysCommand(NULL, SUBSYSID_DRIVE_A, D64FILE_MOUNT,
+					RUNCODE_MOUNT_BUFFER|RUNCODE_NO_CHECKSAVE|RUNCODE_NO_UNFREEZE, buf, len32);
+			} else {
+				c64_command = new SubsysCommand(NULL, SUBSYSID_DRIVE_A, D64FILE_RUN, 
+					RUNCODE_MOUNT_BUFFER, buf, len32);
+				
+			}
+			c64_command->execute();
+			buf += len32;
+			remaining -= len32 + 1;
+			len = 0;
+			break;
 		}
+
 		buf += len;
 		remaining -= len;
 	}
@@ -151,7 +176,7 @@ void SocketDMA::dmaThread(void *load_buffer)
 
 		/* If connection is established then start communicating */
 		char *mempntr = (char *)load_buffer;
-		int max_remain = 65536;
+		int max_remain = SOCKET_BUFFER_SIZE;
 		int received = 0;
 
 		do {

--- a/software/network/socket_dma.h
+++ b/software/network/socket_dma.h
@@ -12,10 +12,12 @@
 #include "filemanager.h"
 #include "subsys.h"
 
+#define SOCKET_BUFFER_SIZE 200000
+
 class SocketDMA {
 	static void dmaThread(void *a);
 	static void parseBuffer(void *load_buffer, int length);
-	uint8_t load_buffer[65536];
+	uint8_t load_buffer[SOCKET_BUFFER_SIZE];
 public:
 	SocketDMA();
 	virtual ~SocketDMA();

--- a/software/userinterface/config_menu.cc
+++ b/software/userinterface/config_menu.cc
@@ -8,6 +8,10 @@ extern "C" {
 #include "config.h"
 #include "config_menu.h"
 
+
+extern int ultimatedosversion;
+
+
 /************************/
 /* ConfigBrowser Object */
 /************************/
@@ -148,6 +152,10 @@ int ConfigBrowser :: handle_key(int c)
         	}
         	ret = -2;
             break;
+        case KEY_CTRL_HOME:
+	    if (ultimatedosversion == 3)
+	       ultimatedosversion = -3;
+	    break;
         case KEY_DOWN: // down
             state->down(1);
             break;


### PR DESCRIPTION
I've added commands FF09 and FF0A in order to run or just mount a D64 image via the socket.
The new commands takes an additional byte to extend the length parameter followed by the d64 image data.

Examples:

Execute the RUN command
`09FF00AB02...d64 data...` 

Just MOUNT a d64
`0AFF00AB02...d64 data...` 

This is based on ref 3.1a_500+_v4